### PR TITLE
Readme: fix nvram documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,10 @@ If the file is absent NVRAM is tried (see down for setting up NVRAM config), sen
 
 ### Setting up NVRAM based config
 From EFI Shell
->setvar CsmWrapConfig -guid 7c436110-ab2a-4fff-a880-fe41995c9f82 \
--bs -rt -nv =L"serial=true;verbose=true;vgabios=\EFI\csmwrap\vgabios.bin"
+>setvar CsmWrapConfig -guid 7c436110-ab2a-4fff-a880-fe41995c9f82 -bs -rt -nv =L"serial=true\nverbose=true\nvgabios=\EFI\csmwrap\vgabios.bin\n"
 
 Or from Linux (efivarfs):
->printf '\x07\x00\x00\x00serial=true;verbose=true;vgabios=...' \> sys/firmware/efi/efivars/CsmWrapConfig-7c436110-ab2a-4fff-a880-fe41995c9f82
+>printf '\x07\x00\x00\x00serial=true\nverbose=true\nvgabios=...' \> sys/firmware/efi/efivars/CsmWrapConfig-7c436110-ab2a-4fff-a880-fe41995c9f82
 
 
 ### Options


### PR DESCRIPTION
The previous one i added was wrong it used ; instead of \n as seperator